### PR TITLE
Add meson build definitions for utf8proc 2.6.0

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,0 +1,26 @@
+project('utf8proc', 'c',
+    version : '2.6.0',
+    license: 'MIT',
+    default_options: ['c_std=c99']
+)
+
+utf8proc_args = []
+
+if get_option('default_library') == 'static'
+    utf8proc_args += '-DUTF8PROC_STATIC'
+endif
+
+utf8proc_lib = library('utf8proc',
+    sources: [
+        'utf8proc.c',
+        'utf8proc.h'
+    ],
+    include_directories: include_directories('.'),
+    c_args: ['-DUTF8PROC_EXPORTS']
+)
+
+utf8proc_dep = declare_dependency(
+    include_directories: include_directories('.'),
+    compile_args: utf8proc_args,
+    link_with: utf8proc_lib
+)

--- a/upstream.wrap
+++ b/upstream.wrap
@@ -1,0 +1,9 @@
+[wrap-file]
+directory = utf8proc-2.6.0
+
+source_url = https://github.com/JuliaStrings/utf8proc/archive/v2.6.0.tar.gz
+source_filename = v2.6.0.tar.gz
+source_hash = b36ce1534b8035e7febd95c031215ed279ee9d31cf9b464e28b4c688133b22c5
+
+[provide]
+libutf8proc = utf8proc_dep


### PR DESCRIPTION
Do I need to port this [MSVC specific part](https://github.com/JuliaStrings/utf8proc/blob/df2997a300792b8efd6a1ea9281c14dfe986d6f9/CMakeLists.txt#L32) to Meson?

```cmake
if (MSVC)
    set_target_properties(utf8proc PROPERTIES OUTPUT_NAME "utf8proc_static")
endif()
```